### PR TITLE
Create api-spec.yaml

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1,0 +1,85 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 1.0.0
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /users/{userId}/profile:
+    get:
+      summary: Get user profile
+      operationId: getUserProfile
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: includeDetails
+          in: query
+          required: false
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: User profile data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                  email:
+                    type: string
+                    format: email
+                  displayName:
+                    type: string
+    put:
+      summary: Update user profile
+      operationId: updateUserProfile
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                displayName:
+                  type: string
+              required:
+                - email
+      responses:
+        '200':
+          description: Update confirmation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                  message:
+                    type: string
+                    


### PR DESCRIPTION
This pull request introduces a new OpenAPI 3.0 specification file (`api-spec.yaml`) for defining the API endpoints and their details. The most significant changes include the addition of two endpoints for managing user profiles (`GET` and `PUT`), along with their parameters, request bodies, and response schemas.

### API Specification Changes:

* **Added OpenAPI 3.0 Specification**: Introduced the `api-spec.yaml` file with basic metadata, including the API title, version, and server URL.

* **`GET /users/{userId}/profile` Endpoint**: Added an endpoint to retrieve user profile data with support for `userId` as a path parameter and an optional `includeDetails` query parameter. The response schema includes `id`, `email`, and `displayName` fields.

* **`PUT /users/{userId}/profile` Endpoint**: Added an endpoint to update user profile information. The request body requires `email` and optionally includes `displayName`. Responses include a success message or an error with a code and message for invalid input.

## Summary by Sourcery

Introduce an OpenAPI 3.0 spec file to document the API metadata and two endpoints for managing user profiles.

New Features:
- Add OpenAPI 3.0 specification file with API metadata and server information
- Define GET /users/{userId}/profile and PUT /users/{userId}/profile endpoints for retrieving and updating user profiles