### PR TITLE
Create request-builder.contract.test.js

### DIFF
--- a/tests/request-builder.contract.test.js
+++ b/tests/request-builder.contract.test.js
@@ -1,0 +1,233 @@
+// tests/request-builder.contract.test.js
+const path = require('path');
+const OpenAPIBackend = require('openapi-backend').default;
+const {
+    buildGetUserProfileRequest,
+    buildUpdateUserProfileRequest
+} = require('../src/request-builder');
+
+describe('Request Builder Contract Tests', () => {
+    let api;
+
+    beforeAll(async () => {
+        api = new OpenAPIBackend({
+            definition: path.resolve(__dirname, '../api-spec.yaml'),
+        });
+        await api.init();
+    });
+
+    function mapAxiosReqToValidationReq(reqObj) {
+        const url = new URL(reqObj.url);
+        const lowercasedHeaders = {};
+        if (reqObj.headers) {
+            for (const key in reqObj.headers) {
+                lowercasedHeaders[key.toLowerCase()] = reqObj.headers[key];
+            }
+        }
+        return {
+            method: reqObj.method.toLowerCase(),
+            path: url.pathname,
+            query: reqObj.params,
+            body: reqObj.data,
+            headers: lowercasedHeaders,
+        };
+    }
+
+    // --- Original Test Cases ---
+    test('buildGetUserProfileRequest should produce a valid request object for spec validation', () => {
+        const userId = 'a1b2c3d4-e5f6-7890-1234-567890abcdef';
+        const includeDetails = true;
+        const reqObj = buildGetUserProfileRequest(userId, includeDetails);
+        const validationReq = mapAxiosReqToValidationReq(reqObj);
+        const validationResult = api.validateRequest(validationReq);
+        expect(validationResult.valid, `Validation Errors: ${JSON.stringify(validationResult.errors, null, 2)}`).toBe(true);
+    });
+
+    test('buildGetUserProfileRequest without optional query param should be valid for spec validation', () => {
+        const userId = 'a1b2c3d4-e5f6-7890-1234-567890abcdef';
+        const includeDetails = undefined;
+        const reqObj = buildGetUserProfileRequest(userId, includeDetails);
+        const validationReq = mapAxiosReqToValidationReq(reqObj);
+        const validationResult = api.validateRequest(validationReq);
+        expect(validationResult.valid, `Validation Errors: ${JSON.stringify(validationResult.errors, null, 2)}`).toBe(true);
+    });
+
+    test('buildUpdateUserProfileRequest should produce a valid request object for spec validation', () => {
+        const userId = 'b2c3d4e5-f6a7-8901-2345-67890abcdef1';
+        const profileData = { email: 'test@example.com', displayName: 'Test User' };
+        const reqObj = buildUpdateUserProfileRequest(userId, profileData);
+        const validationReq = mapAxiosReqToValidationReq(reqObj);
+        const validationResult = api.validateRequest(validationReq);
+        expect(validationResult.valid, `Validation Errors: ${JSON.stringify(validationResult.errors, null, 2)}`).toBe(true);
+    });
+
+    test('buildUpdateUserProfileRequest with missing required body property (caught by builder)', () => {
+        const userId = 'c3d4e5f6-a7b8-9012-3456-7890abcdef12';
+        const invalidProfileData = { displayName: 'Another User' }; // Missing 'email'
+        expect(() => {
+            buildUpdateUserProfileRequest(userId, invalidProfileData);
+        }).toThrow('profileData must contain an email property');
+    });
+
+    test('buildUpdateUserProfileRequest with empty profileData should be caught by builder', () => {
+        const userId = 'd4e5f6a7-b8c9-0123-4567-890abcdef123';
+        expect(() => {
+            buildUpdateUserProfileRequest(userId, {});
+        }).toThrow('profileData object is required and cannot be empty');
+    });
+
+    // --- Test Cases for User ID Handling ---
+
+    describe('Error Handling and Format Validation for userId in buildGetUserProfileRequest', () => {
+        test('should throw an error if userId is null (builder validation)', () => {
+            expect(() => {
+                buildGetUserProfileRequest(null, true);
+            }).toThrow('userId is required');
+        });
+
+        test('should throw an error if userId is undefined (builder validation)', () => {
+            expect(() => {
+                buildGetUserProfileRequest(undefined, true);
+            }).toThrow('userId is required');
+        });
+
+        test('should throw an error if userId is an empty string (builder validation)', () => {
+            expect(() => {
+                buildGetUserProfileRequest('', true);
+            }).toThrow('userId is required');
+        });
+
+        test('should build request but fail spec validation if userId is not a UUID format', () => {
+            const userId = 'not-a-valid-uuid';
+            const reqObj = buildGetUserProfileRequest(userId, false);
+            const validationReq = mapAxiosReqToValidationReq(reqObj);
+            const validationResult = api.validateRequest(validationReq);
+
+            expect(reqObj).toBeDefined();
+            expect(validationResult.valid).toBe(false);
+            expect(validationResult.errors).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        message: expect.stringContaining('should match format "uuid"'),
+                        path: expect.stringContaining('request.path.userId'),
+                    })
+                ])
+            );
+        });
+    });
+
+    describe('Error Handling and Format Validation for userId in buildUpdateUserProfileRequest', () => {
+        const validProfileData = { email: 'test@example.com', displayName: 'Test User' };
+
+        test('should throw an error if userId is null (builder validation)', () => {
+            expect(() => {
+                buildUpdateUserProfileRequest(null, validProfileData);
+            }).toThrow('userId is required');
+        });
+
+        test('should throw an error if userId is undefined (builder validation)', () => {
+            expect(() => {
+                buildUpdateUserProfileRequest(undefined, validProfileData);
+            }).toThrow('userId is required');
+        });
+
+        test('should throw an error if userId is an empty string (builder validation)', () => {
+            expect(() => {
+                buildUpdateUserProfileRequest('', validProfileData);
+            }).toThrow('userId is required');
+        });
+
+        test('should build request but fail spec validation if userId is not a UUID format', () => {
+            const userId = 'another-invalid-uuid-format';
+            const reqObj = buildUpdateUserProfileRequest(userId, validProfileData);
+            const validationReq = mapAxiosReqToValidationReq(reqObj);
+            const validationResult = api.validateRequest(validationReq);
+
+            expect(reqObj).toBeDefined();
+            expect(validationResult.valid).toBe(false);
+            expect(validationResult.errors).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        message: expect.stringContaining('should match format "uuid"'),
+                        path: expect.stringContaining('request.path.userId'),
+                    })
+                ])
+            );
+        });
+    });
+
+    // --- New Test Cases for Request Body Validation (buildUpdateUserProfileRequest) ---
+
+    describe('Request Body Validation for buildUpdateUserProfileRequest', () => {
+        const userId = 'valid-user-id-for-body-tests'; // Use a consistent, valid-looking ID for these tests
+
+        test('should fail spec validation if request body has incorrect data type for email', () => {
+            const profileData = { email: 12345, displayName: 'Test User with Invalid Email Type' };
+            // Note: The builder's current validation only checks for presence of 'email', not its type.
+            const reqObj = buildUpdateUserProfileRequest(userId, profileData);
+            const validationReq = mapAxiosReqToValidationReq(reqObj);
+            const validationResult = api.validateRequest(validationReq);
+
+            expect(reqObj).toBeDefined();
+            expect(validationResult.valid).toBe(false);
+            expect(validationResult.errors).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        message: expect.stringContaining('should be string'), // Error for type mismatch
+                        path: expect.stringContaining('request.body.email'),
+                    })
+                ])
+            );
+        });
+
+        test('should fail spec validation if request body has incorrect data type for optional displayName', () => {
+            const profileData = { email: 'correct@example.com', displayName: 12345 }; // displayName should be string
+            const reqObj = buildUpdateUserProfileRequest(userId, profileData);
+            const validationReq = mapAxiosReqToValidationReq(reqObj);
+            const validationResult = api.validateRequest(validationReq);
+
+            expect(reqObj).toBeDefined();
+            expect(validationResult.valid).toBe(false);
+            expect(validationResult.errors).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        message: expect.stringContaining('should be string'),
+                        path: expect.stringContaining('request.body.displayName'),
+                    })
+                ])
+            );
+        });
+
+        test('should fail spec validation if request body contains additional, unspecified properties', () => {
+            const profileData = {
+                email: 'test@example.com',
+                displayName: 'Test User',
+                unexpectedProperty: 'someValue' // This property is not defined in the api-spec.yaml
+            };
+            const reqObj = buildUpdateUserProfileRequest(userId, profileData);
+            const validationReq = mapAxiosReqToValidationReq(reqObj);
+            const validationResult = api.validateRequest(validationReq);
+
+            expect(reqObj).toBeDefined();
+            expect(validationResult.valid).toBe(false); // OpenAPI 3.0 default is additionalProperties: false for objects unless specified
+            expect(validationResult.errors).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        message: expect.stringMatching(/additional properties|should NOT have additional properties/i),
+                        path: expect.stringContaining('request.body'), // Error points to the body object
+                    })
+                ])
+            );
+        });
+
+        test('should pass spec validation if optional displayName in request body is omitted', () => {
+            const profileData = { email: 'onlyemail@example.com' }; // displayName is optional
+            const reqObj = buildUpdateUserProfileRequest(userId, profileData);
+            const validationReq = mapAxiosReqToValidationReq(reqObj);
+            const validationResult = api.validateRequest(validationReq);
+
+            expect(validationResult.valid, `Validation Errors: ${JSON.stringify(validationResult.errors, null, 2)}`).toBe(true);
+        });
+    });
+});
+          


### PR DESCRIPTION
This pull request introduces comprehensive contract tests for the `request-builder` module to ensure that request objects conform to the OpenAPI specification. It includes tests for validating the structure and content of request objects, as well as error handling for invalid inputs. The changes improve test coverage and robustness of the request-building logic.

### New Contract Tests for Request Validation:
* Added a test suite in `tests/request-builder.contract.test.js` to validate request objects against the OpenAPI specification using `OpenAPIBackend`. This ensures compliance with the API contract.

### Error Handling for `userId`:
* Implemented tests to validate `userId` handling in `buildGetUserProfileRequest` and `buildUpdateUserProfileRequest`. These tests check for null, undefined, empty strings, and non-UUID formats, ensuring proper error handling and validation.

### Request Body Validation:
* Added tests to validate the structure and data types of the request body for `buildUpdateUserProfileRequest`. These include checks for incorrect data types, additional unspecified properties, and optional fields.

### Builder-Level Validation:
* Added tests to verify that the request builder throws appropriate errors for missing or invalid required fields, such as `userId` and `profileData`.

## Summary by Sourcery

Add comprehensive OpenAPI-based contract tests for the request-builder module to ensure generated requests conform to the API specification and to validate error handling and request body schemas.

Tests:
- Add contract tests for buildGetUserProfileRequest and buildUpdateUserProfileRequest against the OpenAPI specification
- Validate builder error handling for invalid userId inputs including null, undefined, empty, and non-UUID formats
- Assert builder-level errors for missing or incomplete profileData in update requests
- Verify request body validation failures for incorrect data types, unexpected properties, and correct handling of optional fields