### PR TITLE
Create api-spec.yaml

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -1,0 +1,107 @@
+openapi: 3.0.0
+info:
+  title: Sample API
+  version: 1.0.0
+  description: A simple API for demonstrating request builder contract testing.
+servers:
+  - url: https://api.example.com/v1
+paths:
+  /users/{userId}/profile:
+    get:
+      summary: Get user profile
+      operationId: getUserProfile
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          example: "a1b2c3d4-e5f6-7890-1234-567890abcdef"
+          description: The ID of the user to retrieve.
+        - name: includeDetails
+          in: query
+          required: false
+          schema:
+            type: boolean
+          example: true
+          description: Whether to include detailed information in the response.
+      responses:
+        '200':
+          description: User profile data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    format: uuid
+                    example: "f4a7b8c9-d0e1-2345-6789-0abcdef12345"
+                    description: The unique ID of the user.
+                  email:
+                    type: string
+                    format: email
+                    example: "test@example.com"
+                    description: The user's email address.
+                  displayName:
+                    type: string
+                    example: "Test User"
+                    description: The user's display name.
+    put:
+      summary: Update user profile
+      operationId: updateUserProfile
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          example: "b2c3d4e5-f6a7-8901-2345-67890abcdef1"
+          description: The ID of the user to update.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  format: email
+                  example: "updated@example.com"
+                  description: The user's updated email address.
+                displayName:
+                  type: string
+                  example: "Updated User Name"
+                  description: The user's updated display name.
+              required:
+                - email
+      responses:
+        '200':
+          description: Update confirmation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Profile updated successfully."
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 1001
+                    description: An error code.
+                  message:
+                    type: string
+                    example: "Invalid email format."
+                    description: A human-readable error message.
+                    


### PR DESCRIPTION
This pull request introduces a new OpenAPI 3.0 specification file (`api-spec.yaml`) to define the contract for a sample API. The specification includes endpoints for retrieving and updating user profiles, with detailed request and response schemas.

### New API Specification:

* Added `api-spec.yaml` to define the API contract using OpenAPI 3.0.0. The file includes metadata such as the API title, version, and server URL.

### Endpoints:

* **GET `/users/{userId}/profile`**: Defines an endpoint to retrieve a user's profile. It includes path and query parameters (`userId` and `includeDetails`) and a response schema specifying user details like `id`, `email`, and `displayName`.
* **PUT `/users/{userId}/profile`**: Defines an endpoint to update a user's profile. It includes a required path parameter (`userId`), a request body schema for updating `email` and `displayName`, and response schemas for success (`200`) and error (`400`) cases.

## Summary by Sourcery

Introduce an OpenAPI 3.0 specification file to define the sample API contract for user profiles.

New Features:
- Add GET /users/{userId}/profile endpoint with path and query parameters and a response schema.
- Add PUT /users/{userId}/profile endpoint with path parameter, request body schema, and success and error responses.

Documentation:
- Add api-spec.yaml with API metadata (title, version, description) and server URL configuration.